### PR TITLE
updated readme with arch relevant instructions as well as a possible dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,12 +11,24 @@ Don't be like Wojak.
 
 ## How to install
 Since this is a conky theme, it requires [conky](https://github.com/brndnmtthws/conky) to be installed. If you don't have conky already you can install it using
-```
+```bash
+# Debian based distribution:
 sudo apt install conky-all
+
+# Arch based distribution:
+sudo pacman -S conky
+```
+You may or may not also have to install jq (depending on your linux distribution). In case you need to, it can be installed using
+```bash
+# Debian based distribution:
+sudo apt install jq
+
+# Arch based distribution:
+sudo pacman -S jq
 ```
 
 Clone the repo to your home directory, navigate to the folder and run
-```
+```bash
 bash install.sh
 ```
 


### PR DESCRIPTION
Although common, jq is not installed by default on all linux distributions (min for example). If it is not installed an error is looped over and over since the statements in the conditions can't be run. I add information on this as well as how to install it on arch and debiand based distributions.

I also added bash-specification to the code blocks to (hopefully) improve formatting (at this point, to display comments with a darker font) somewhat.