### PR TITLE
Change override_utf8_locale to true

### DIFF
--- a/conky-config
+++ b/conky-config
@@ -33,7 +33,7 @@ conky.config = {
 		xftalpha = 0,
 		font = 'Forque:size=10',
 	
-		override_utf8_locale = false,
+		override_utf8_locale = true,
 		imlib_cache_size = 0,
 	
 	-- Color scheme #


### PR DESCRIPTION
Change override_utf8_locale to true according to @wfenglund suggestion after successful test on Ubuntu 22.04-based system (Pop!_OS 22.04).